### PR TITLE
환율

### DIFF
--- a/TcPCM_Connect/Master/frmCategory.Designer.cs
+++ b/TcPCM_Connect/Master/frmCategory.Designer.cs
@@ -135,7 +135,8 @@
             "공간 생산 비용",
             "전력단가",
             "임률",
-            "단위"});
+            "단위",
+            "환율"});
             this.cb_Classification.ListBackColor = System.Drawing.Color.White;
             this.cb_Classification.ListTextColor = System.Drawing.Color.DimGray;
             this.cb_Classification.Location = new System.Drawing.Point(67, 24);

--- a/TcPCM_Connect_Global/Excel/ExcelImport.cs
+++ b/TcPCM_Connect_Global/Excel/ExcelImport.cs
@@ -1004,7 +1004,7 @@ namespace TcPCM_Connect_Global
                                 flag = true;
 
                                 dgv.Rows[dgv.Rows.Count-1].Cells[col.Name].Value = resultValue;
-                                if (new List<string>() { "지역", "공정", "업종", "설비명", "설비구분", "통화", "Valid From", "구분 1", "재료명", "메이커", "구분", "비중", "비중 단위", "가격 단위", "스크랩 비용 단위", "이름", "ISO","UOM Code", "UOM 명" }.Contains(col.Name)) continue;
+                                if (new List<string>() { "지역", "공정", "업종", "설비명", "설비구분", "통화", "Valid From", "구분자", "재료명", "메이커", "구분", "비중", "비중 단위", "가격 단위", "스크랩 비용 단위", "이름", "ISO","UOM Code", "UOM 명" }.Contains(col.Name)) continue;
 
                                 if ((((col.Name.Contains("율") || col.Name.Contains("률")) && !col.Name.Contains("임률") && !col.Name.Contains("환율")))&& !col.Name.Contains("수선비율"))
                                 {

--- a/TcPCM_Connect_Global/Master/CostFactor.cs
+++ b/TcPCM_Connect_Global/Master/CostFactor.cs
@@ -79,6 +79,25 @@ namespace TcPCM_Connect_Global
                 }), err);
 
             }
+            if(name == "환율")
+            {
+                JObject postData = new JObject
+                {
+                    { "Data", category },
+                    { "ConfigurationGuid", global_iniLoad.GetConfig(className, name) }
+                };
+                err = WebAPI.ErrorCheck(WebAPI.POST(callUrl, postData), err);
+
+                if (err == null)
+                {
+                    postData = new JObject
+                    {
+                        { "Data", category },
+                        { "ConfigurationGuid", global_iniLoad.GetConfig(className, name+"_Detail") }
+                    };
+                    err = WebAPI.ErrorCheck(WebAPI.POST(callUrl, postData), err);
+                }
+            }
             else
             {
                 JObject postData = new JObject


### PR DESCRIPTION
1.검색
1-1.분류 콤보 박스(cb_Classification)에 환율 추가.
1-2.콤보 박스 선택시 화면에 환율 테이블이 생성되도록 추가.
1-3.검색시 환율 내용이 검색되도록 쿼리문 추가.
1-4.검색 쿼리문에 관련된 코드 로직 변경.

2.저장
2-1.환율을 Import시 CostFactor.Import에 환율과 환율_Detail 2개를 Post하도록 코드 추가.

3.엑셀 Import
3-1.LoadMasterData의 무결성 검사 통과 기준에 "구분자" 추가

4.엑셀 Export
5.환율 표시에 천 단위마다 ','가 붙어 구분되도록 추가.(소수점 2자리 수 까지 표기)