### PR TITLE
지역과 업종 생성 방식 변경.

### DIFF
--- a/TcPCM_Connect/Dashboard/test.Designer.cs
+++ b/TcPCM_Connect/Dashboard/test.Designer.cs
@@ -1,0 +1,60 @@
+﻿
+namespace TcPCM_Connect.Dashboard
+{
+    partial class test
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button2 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(713, 12);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 1;
+            this.button2.Text = "button2";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // test
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.button2);
+            this.Name = "test";
+            this.Text = "test";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+        private System.Windows.Forms.Button button2;
+    }
+}

--- a/TcPCM_Connect/Dashboard/test.cs
+++ b/TcPCM_Connect/Dashboard/test.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace TcPCM_Connect.Dashboard
+{
+    public partial class test : Form
+    {
+        public test()
+        {
+            InitializeComponent();
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            TcPCM_Connect_Global.ManufacturingLibrary library = new TcPCM_Connect_Global.ManufacturingLibrary();
+            string err = library.ExcelOpen();
+
+            if (err != null)
+                CustomMessageBox.RJMessageBox.Show($"불러오기에 실패하였습니다\nError : {err}", "Cost factor", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            else
+            {
+
+            }
+        }
+    }
+}

--- a/TcPCM_Connect/Dashboard/test.resx
+++ b/TcPCM_Connect/Dashboard/test.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/TcPCM_Connect/Master/frmCategory.Designer.cs
+++ b/TcPCM_Connect/Master/frmCategory.Designer.cs
@@ -28,11 +28,11 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
             this.roundBorderPanel2 = new TcPCM_Connect.RoundBorderPanel();
             this.btn_ExcelCreate = new CustomControls.RJControls.RJButton();
             this.searchButton1 = new TcPCM_Connect.Controller.SearchButton();
@@ -42,6 +42,7 @@
             this.btn_Save = new CustomControls.RJControls.RJButton();
             this.dgv_Category = new System.Windows.Forms.DataGridView();
             this.btn_Create = new CustomControls.RJControls.RJButton();
+            this.testButton = new System.Windows.Forms.Button();
             this.roundBorderPanel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_Category)).BeginInit();
             this.SuspendLayout();
@@ -55,6 +56,7 @@
             this.roundBorderPanel2.BorderColor = System.Drawing.Color.Gainsboro;
             this.roundBorderPanel2.BorderRadius = 10;
             this.roundBorderPanel2.BorderSize = 1;
+            this.roundBorderPanel2.Controls.Add(this.testButton);
             this.roundBorderPanel2.Controls.Add(this.btn_ExcelCreate);
             this.roundBorderPanel2.Controls.Add(this.searchButton1);
             this.roundBorderPanel2.Controls.Add(this.label2);
@@ -194,10 +196,10 @@
             // dgv_Category
             // 
             this.dgv_Category.AllowUserToAddRows = false;
-            dataGridViewCellStyle16.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
-            dataGridViewCellStyle16.SelectionBackColor = System.Drawing.SystemColors.Menu;
-            dataGridViewCellStyle16.SelectionForeColor = System.Drawing.Color.DimGray;
-            this.dgv_Category.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle16;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Menu;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.DimGray;
+            this.dgv_Category.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
             this.dgv_Category.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
@@ -206,45 +208,45 @@
             this.dgv_Category.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.dgv_Category.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
             this.dgv_Category.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle17.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle17.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(38)))), ((int)(((byte)(45)))), ((int)(((byte)(53)))));
-            dataGridViewCellStyle17.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle17.ForeColor = System.Drawing.Color.White;
-            dataGridViewCellStyle17.SelectionBackColor = System.Drawing.SystemColors.Menu;
-            dataGridViewCellStyle17.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle17.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgv_Category.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle17;
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(38)))), ((int)(((byte)(45)))), ((int)(((byte)(53)))));
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle2.ForeColor = System.Drawing.Color.White;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Menu;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgv_Category.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle2;
             this.dgv_Category.ColumnHeadersHeight = 40;
-            dataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle18.BackColor = System.Drawing.SystemColors.ButtonHighlight;
-            dataGridViewCellStyle18.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle18.ForeColor = System.Drawing.Color.Black;
-            dataGridViewCellStyle18.SelectionBackColor = System.Drawing.SystemColors.MenuHighlight;
-            dataGridViewCellStyle18.SelectionForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            dataGridViewCellStyle18.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgv_Category.DefaultCellStyle = dataGridViewCellStyle18;
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ButtonHighlight;
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle3.ForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.MenuHighlight;
+            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.ButtonHighlight;
+            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgv_Category.DefaultCellStyle = dataGridViewCellStyle3;
             this.dgv_Category.EnableHeadersVisualStyles = false;
             this.dgv_Category.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(38)))), ((int)(((byte)(45)))), ((int)(((byte)(53)))));
             this.dgv_Category.Location = new System.Drawing.Point(26, 78);
             this.dgv_Category.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.dgv_Category.Name = "dgv_Category";
             this.dgv_Category.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
-            dataGridViewCellStyle19.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle19.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(38)))), ((int)(((byte)(45)))), ((int)(((byte)(53)))));
-            dataGridViewCellStyle19.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle19.ForeColor = System.Drawing.Color.PaleVioletRed;
-            dataGridViewCellStyle19.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle19.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle19.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgv_Category.RowHeadersDefaultCellStyle = dataGridViewCellStyle19;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(38)))), ((int)(((byte)(45)))), ((int)(((byte)(53)))));
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle4.ForeColor = System.Drawing.Color.PaleVioletRed;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgv_Category.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
             this.dgv_Category.RowHeadersVisible = false;
             this.dgv_Category.RowHeadersWidth = 32;
-            dataGridViewCellStyle20.BackColor = System.Drawing.Color.White;
-            dataGridViewCellStyle20.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle20.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
-            dataGridViewCellStyle20.SelectionBackColor = System.Drawing.SystemColors.GradientActiveCaption;
-            dataGridViewCellStyle20.SelectionForeColor = System.Drawing.Color.White;
-            this.dgv_Category.RowsDefaultCellStyle = dataGridViewCellStyle20;
+            dataGridViewCellStyle5.BackColor = System.Drawing.Color.White;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.GradientActiveCaption;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.Color.White;
+            this.dgv_Category.RowsDefaultCellStyle = dataGridViewCellStyle5;
             this.dgv_Category.RowTemplate.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             this.dgv_Category.RowTemplate.DefaultCellStyle.BackColor = System.Drawing.Color.White;
             this.dgv_Category.RowTemplate.DefaultCellStyle.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -280,6 +282,16 @@
             this.btn_Create.UseVisualStyleBackColor = false;
             this.btn_Create.Click += new System.EventHandler(this.btn_Create_Click);
             // 
+            // testButton
+            // 
+            this.testButton.Location = new System.Drawing.Point(800, 465);
+            this.testButton.Name = "testButton";
+            this.testButton.Size = new System.Drawing.Size(87, 32);
+            this.testButton.TabIndex = 67;
+            this.testButton.Text = "testButton";
+            this.testButton.UseVisualStyleBackColor = true;
+            this.testButton.Click += new System.EventHandler(this.testButton_Click);
+            // 
             // frmCategory
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
@@ -308,5 +320,6 @@
         private System.Windows.Forms.Label label2;
         private Controller.SearchButton searchButton1;
         private CustomControls.RJControls.RJButton btn_ExcelCreate;
+        private System.Windows.Forms.Button testButton;
     }
 }

--- a/TcPCM_Connect/TcPCM_Connect.csproj
+++ b/TcPCM_Connect/TcPCM_Connect.csproj
@@ -179,6 +179,12 @@
     <Compile Include="Dashboard\frmDashboard.Designer.cs">
       <DependentUpon>frmDashboard.cs</DependentUpon>
     </Compile>
+    <Compile Include="Dashboard\test.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Dashboard\test.Designer.cs">
+      <DependentUpon>test.cs</DependentUpon>
+    </Compile>
     <Compile Include="frmMain.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -273,6 +279,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Dashboard\frmDashboard.resx">
       <DependentUpon>frmDashboard.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Dashboard\test.resx">
+      <DependentUpon>test.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="frmMain.resx">
       <DependentUpon>frmMain.cs</DependentUpon>

--- a/TcPCM_Connect_Global/Excel/ExcelExport.cs
+++ b/TcPCM_Connect_Global/Excel/ExcelExport.cs
@@ -538,8 +538,10 @@ namespace TcPCM_Connect_Global
                 worksheet.Visible = Excel.XlSheetVisibility.xlSheetVisible;
 
                 int lastCount = dgv.ColumnCount;
-                if (columnName == "지역" || columnName == "업종" || columnName == "단위")
+                if (columnName == "지역" || columnName == "단위")
                     lastCount--;
+                else if (columnName == "업종")
+                    lastCount = lastCount - 2;
 
                 for(int i =0 ; i < lastCount; i++)
                 {

--- a/TcPCM_Connect_Global/Excel/ManufacturingLibrary.cs
+++ b/TcPCM_Connect_Global/Excel/ManufacturingLibrary.cs
@@ -1,0 +1,193 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace TcPCM_Connect_Global
+{
+    public class ManufacturingLibrary
+    {
+        string sheetName;
+        public string ExcelOpen()
+        {
+            Excel.Application application = null;
+            Excel.Workbook workBook = null;
+            try
+            {
+                OpenFileDialog dlg = new OpenFileDialog();
+
+                DialogResult dialog = dlg.ShowDialog();
+                if (dialog == DialogResult.Cancel)
+                    return null;
+                else if (dialog != DialogResult.OK)
+                    return "ERROR : 파일 오픈에 실패하였습니다.";
+
+                //Excel 프로그램 실행
+                application = new Microsoft.Office.Interop.Excel.Application();
+                //Excel 화면 띄우기 옵션
+                application.Visible = false;
+                //파일로부터 불러오기
+                workBook = application.Workbooks.Open(dlg.FileName);
+
+                List<string> workSheetList = new List<string>();
+                foreach (Excel.Worksheet sheet in workBook.Worksheets)
+                {
+                    if (sheet.Visible == Excel.XlSheetVisibility.xlSheetVisible) workSheetList.Add(sheet.Name);
+                }
+                workSheetSelect sheetSelect = new workSheetSelect();
+                sheetSelect.workSheet = workSheetList;
+
+                if (sheetSelect.ShowDialog() == DialogResult.Cancel)
+                    return null;
+                string sheetName = sheetSelect.ReturnValue1;
+
+                Excel.Worksheet worksheet = workBook.Worksheets.Item[sheetName];
+
+                LoadData(worksheet, sheetName);
+
+                return null;
+            }
+            catch (Exception exc)
+            {
+                return exc.Message;
+            }
+            finally
+            {
+                if (workBook != null)
+                {
+                    //변경점 저장 안하면서 닫기
+                    workBook.Close(false);
+                    //Excel 프로그램 종료
+                    application.Quit();
+                    //오브젝트 해제1
+                    ExcelCommon.ReleaseExcelObject(workBook);
+                    ExcelCommon.ReleaseExcelObject(application);
+                }
+            }
+        }
+        public void LoadData(Excel.Worksheet worksheet, string sheetName)
+        {
+            object[,] xlRng = worksheet.UsedRange.get_Value(Excel.XlRangeValueDataType.xlRangeValueDefault);
+            string[] keys = new string[xlRng.GetUpperBound(1) + 1];
+            int firstCol = 0, firstRow = 0, cosumRateIndex = 0;
+
+            for (firstRow = xlRng.GetLowerBound(0); firstRow <= xlRng.GetUpperBound(0); firstRow++)
+            {
+                for (int col = xlRng.GetLowerBound(1); col <= xlRng.GetUpperBound(1); col++)
+                {
+                    if (xlRng[firstRow, col] == null)
+                        continue;
+                    if (firstCol == 0)
+                        firstCol = col;
+
+                    keys[col] = xlRng[firstRow, col]?.ToString();
+                    if (keys[col].Contains("전력소비율"))
+                        cosumRateIndex = col;
+                }
+                if (!keys.All(x => x == null)) break;
+            }
+
+            List<Dictionary<string, string>> values = new List<Dictionary<string, string>>();
+            List<List<string>> cosumRateList = new List<List<string>>();
+            for (int row = firstRow + 2; row <= xlRng.GetUpperBound(0); row++)
+            {
+                var rowData = new Dictionary<string, string>();
+                for (int col = xlRng.GetLowerBound(1); col <= xlRng.GetUpperBound(1); col++)
+                {
+                    string key = keys[col - xlRng.GetLowerBound(1)];
+                    if (key != null)
+                    {
+                        if (key.Contains("설비명"))
+                        {
+                            rowData["기계명"] = xlRng[row, col - xlRng.GetLowerBound(1)] == null ? null : xlRng[row, col - xlRng.GetLowerBound(1)].ToString();
+                        }
+                        rowData[key] = xlRng[row, col - xlRng.GetLowerBound(1)] == null ? null : xlRng[row, col - xlRng.GetLowerBound(1)].ToString();
+                    }
+                }
+                values.Add(rowData); // 행 데이터를 리스트에 추가
+
+                List<string> minMaxAvg = new List<string>();
+                for (int i = cosumRateIndex; i < cosumRateIndex + 3; i++)
+                {
+                    minMaxAvg.Add(xlRng[row, i].ToString());
+                }
+                cosumRateList.Add(minMaxAvg);
+            }
+
+            for (int i=0; i<values.Count; i++)
+            {
+                MakePostData(values[i], cosumRateList[i], sheetName);
+            }
+        }
+        public void MakePostData(Dictionary<string, string> keyValues, List<string> cosumRateList, string sheetName)
+        {
+            String callUrl = $"{global.serverURL}/{global.serverURLPath}/api/{global.version}/MasterData/Import";
+            string err = null;
+
+            JArray category = new JArray();
+            JObject item = new JObject();
+
+            string[] dArray = { "Cycle time", "Cavity", "Set - up time", "Utilization ratio" };
+            string[] rArray = { "Number of workers" };
+            string[] aArray = { "기계명", "공정 형태", "Number of Machine", "Attended system", "설비가", "설치면적", "전력량", "전력소비율", "설비내용년수", "수선/개조비", "설비구분" };
+
+            string[] allArray = dArray.Concat(rArray).Concat(aArray).ToArray();
+
+            item.Add("품번", "");
+            item.Add("품명", sheetName);
+            item.Add("Assembly level", 1);
+            //item.Add("Line Type", "M");
+            //category.Add(item);
+            category.Add(MakeJArray(keyValues, item, allArray, null, "M"));
+
+            item = new JObject();
+            item.Add("품번", "10");
+            item.Add("품명", sheetName);
+            item.Add("Assembly level", 2);
+
+            JObject item2 = (JObject)item.DeepClone();
+            item2.Add("기계명",keyValues["설비명"]);
+            
+            category.Add(MakeJArray(keyValues, item, allArray, dArray, "D"));
+            category.Add(MakeJArray(keyValues, item, allArray, rArray, "R"));
+            category.Add(MakeJArray(keyValues, item2, allArray, aArray, "A"));
+
+            JObject postData = new JObject
+                {
+                    { "Data", category },
+                    { "ConfigurationGuid", "6abf068a-2bc8-49fa-90b4-4e794c686b6e" }
+                };
+            err = WebAPI.ErrorCheck(WebAPI.POST(callUrl, postData), err);
+        }
+
+        public JObject MakeJArray(Dictionary<string, string> keyValues, JObject item, string[] All, string[] array, string LineType)
+        {
+            JObject item2 = (JObject)item.DeepClone();
+
+            item2.Add("Line Type", LineType);
+            try
+            {
+                foreach (var a in keyValues)
+                {
+                    //if (All.Contains(a.Key))
+                    //{
+
+                    //}
+                    if (array != null && array.Contains(a.Key))
+                        item2.Add(a.Key, a.Value);
+                    else
+                        item2.Add(a.Key, null);
+                }
+            }
+            catch
+            {
+
+            }
+            return item2;
+        }
+    }
+}

--- a/TcPCM_Connect_Global/Master/CostFactor.cs
+++ b/TcPCM_Connect_Global/Master/CostFactor.cs
@@ -30,6 +30,14 @@ namespace TcPCM_Connect_Global
                 {
                     if (row.Cells[col.Name].Value != null && !col.Name.ToLower().Contains("valid")) nullCheck = true;
 
+                    if (name == "Plant")// && col.Name.Contains("지역"))
+                    {
+                        item.Add("지역", row.Cells[col.Name].Value?.ToString());
+                        item.Add("Designation", "[DYA]"+row.Cells[col.Name].Value?.ToString());
+                        item.Add("Number", row.Cells[col.Name].Value?.ToString());
+                        break;
+                    }
+
                     if (col.Name.Contains("연간 작업 일수"))
                         item.Add(col.Name, global.ConvertDouble(row.Cells[col.Name].Value) * global.ConvertDouble(row.Cells["Shift 당 작업 시간"].Value) * global.ConvertDouble(row.Cells["Shift"].Value));
                     else if (col.Name.Contains("Labor"))
@@ -40,8 +48,6 @@ namespace TcPCM_Connect_Global
                         addictionalItem.Add("구분", categoryName);
                         if (nullCheck) categoryLabor.Add(addictionalItem);
                     }
-                    //else if (col.Name.Contains("지역") || col.Name.Contains("업종"))
-                    //    item.Add("UniqueId", row.Cells[col.Name].Value?.ToString());
                     else
                         item.Add(col.Name, row.Cells[col.Name].Value?.ToString());
                 }
@@ -117,6 +123,41 @@ namespace TcPCM_Connect_Global
                     };
                 err = WebAPI.ErrorCheck(WebAPI.POST(callUrl, postData), err);
             }
+
+            return err;
+        }
+
+        public string SegmantImport(string className, string name, DataGridView dgv, List<string> segmantList)
+        {
+            String callUrl = $"{global.serverURL}/{global.serverURLPath}/api/{global.version}/MasterData/Import";
+
+            JArray category = new JArray();
+            JArray categoryLabor = new JArray();
+
+            foreach (DataGridViewRow row in dgv.Rows)
+            {
+                foreach(string segmant in segmantList)
+                {
+                    JObject item = new JObject();
+                    bool nullCheck = false;
+
+                    if (row.Cells["지역"].Value != null) nullCheck = true;
+
+                    item.Add(name, segmant);
+                    item.Add("Designation", "[DYA]" + segmant);
+                    item.Add("Plant", row.Cells["지역"].Value?.ToString());
+                    if (nullCheck) category.Add(item);
+                    else break;
+                }
+            }
+            string err = null;
+
+            JObject postData = new JObject
+            {
+                { "Data", category },
+                { "ConfigurationGuid", global_iniLoad.GetConfig(className, name.Replace(" ","")) }
+            };
+            err = WebAPI.ErrorCheck(WebAPI.POST(callUrl, postData), err);
 
             return err;
         }

--- a/TcPCM_Connect_Global/TcPCM_Connect_Global.csproj
+++ b/TcPCM_Connect_Global/TcPCM_Connect_Global.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Excel\frmMachineSelect.Designer.cs">
       <DependentUpon>frmMachineSelect.cs</DependentUpon>
     </Compile>
+    <Compile Include="Excel\ManufacturingLibrary.cs" />
     <Compile Include="Global\Part.cs" />
     <Compile Include="Dashboard\ExportCBD.cs" />
     <Compile Include="Excel\ExcelCommon.cs" />


### PR DESCRIPTION
업종을 만들 때, <업종> 이 아니라 <Segmant>를 사용하는 방식으로 변경되었다.
그에 따라 지역->Plant->Segmant 순으로 연결고리를 만들 필요가 발생했다.

지역
1.지역을 만든다.
2.지역과 동일한 이름의 Plant를 만든다.
3.해당 Plant를 만들고, 모든 Segmant 이름을 가져와서, 해당 Plant를 참조하는 Segmant들을 만든다. ex)'유토피아'라는 지역을 만들면, 동시에 유토피아라는 Plant가 만들어지고, 유토피아-삽입, 유토피아-프레스 등의 Segmant들이 함께 만들어진다.

업종
1.업종(Segmant)을 만들 때, 모든 Plant 이름(혹은 Id?)를 찾아서 싹 다 만든다. ex)[DYA]한국,[DYA]미국,[DYA]유럽이 있을 때, '압착'이라는 Segmant를 만들면 한국-압착, 미국-압착, 유럽-압착 과 같이 3개의 Segmant가 생성된다.