### PR TITLE
Material&재료 수정 및 추가.

### DIFF
--- a/TcPCM_Connect/Master/frmMaterial.Designer.cs
+++ b/TcPCM_Connect/Master/frmMaterial.Designer.cs
@@ -85,7 +85,7 @@
             this.btn_DBLoad.Name = "btn_DBLoad";
             this.btn_DBLoad.Size = new System.Drawing.Size(114, 39);
             this.btn_DBLoad.TabIndex = 65;
-            this.btn_DBLoad.Text = "불러오기";
+            this.btn_DBLoad.Text = "DB 불러오기";
             this.btn_DBLoad.TextColor = System.Drawing.Color.FromArgb(((int)(((byte)(34)))), ((int)(((byte)(116)))), ((int)(((byte)(71)))));
             this.btn_DBLoad.UseVisualStyleBackColor = false;
             this.btn_DBLoad.Visible = false;

--- a/TcPCM_Connect_Global/Excel/ExcelImport.cs
+++ b/TcPCM_Connect_Global/Excel/ExcelImport.cs
@@ -364,14 +364,16 @@ namespace TcPCM_Connect_Global
                                 key = "지역";
                             if (key == "재료명")
                                 key = "재질명";
+                            if (key == "segmant")
+                                key = "업종";
                             if (worksheetName == "재료관리비")
                             {
                                 if (key.Contains("재료") && key.Contains("Loss") && key.Contains("율"))
                                     key = "재료 관리비율";
                             }
-                            //if(!keys.Any(item => item == key))
-                            //    keys[col] = key;
-                            keys[col] = key;
+                            if (!keys.Any(item => item == key))
+                                keys[col] = key;
+                            //keys[col] = key;
                         }
 
                         if (!keys.All(x => x == null))
@@ -403,6 +405,11 @@ namespace TcPCM_Connect_Global
                                     {
                                         dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Style.BackColor = Color.Yellow;
                                     }
+                                    if(col.Name.ToLower().Contains("valid") && !dateTypeCheck)
+                                    {
+                                        flag = false;
+                                        break;
+                                    }
 
                                     flag = true;
 
@@ -418,6 +425,24 @@ namespace TcPCM_Connect_Global
                                     {
                                         dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Value = global.ConvertDouble(resultValue) * 100;
                                     }
+                                    if (!double.TryParse(resultValue, out double resultDouble)) dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Style.BackColor = Color.Yellow;
+                                }
+                                else if (keys[category] == "임률" && !keys.Where(key => key != keys[category]).Any(key => key == col.Name))
+                                {
+                                    if (xlRng[row, category] == null)
+                                    {
+                                        dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Style.BackColor = Color.Red;
+                                        continue;
+                                    }
+
+                                    bool dateTypeCheck = global.TryFormat("{####-##-##}", out string resultValue, xlRng[row, category].ToString());
+                                    if ((col.Name.ToLower().Contains("valid") && !dateTypeCheck) || (!col.Name.ToLower().Contains("valid") && dateTypeCheck))
+                                    {
+                                        dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Style.BackColor = Color.Yellow;
+                                    }
+
+                                    flag = true;
+                                    dgv.Rows[dgv.Rows.Count - 1].Cells["직접임률"].Value = global.ConvertDouble(resultValue);
                                     if (!double.TryParse(resultValue, out double resultDouble)) dgv.Rows[dgv.Rows.Count - 1].Cells[col.Name].Style.BackColor = Color.Yellow;
                                 }
                             }

--- a/TcPCM_Connect_Global/Master/Material.cs
+++ b/TcPCM_Connect_Global/Master/Material.cs
@@ -62,10 +62,11 @@ namespace TcPCM_Connect_Global
                             materials = "Siemens.TCPCM.Classification.Material.RawMaterial.CastingMaterial";
                         else if (materialName == "플라스틱")
                             materials = "Siemens.TCPCM.Classification.Material.RawMaterial.Plastic";
-                        else if (materialName == "철판" || materialName == "철강" || materialName == "특수강" || materialName == "스테인리스강")
+                        else if (materialName == "철판" || materialName == "철강" || materialName == "스테인리스강")
                              materials = "Siemens.TCPCM.Classification.Material.SemiFinished.SheetMetal.Plate";
                         else
-                            materials = "";
+                            materials = "Siemens.TCPCM.Classification.Material.RawMaterial.Plastic";
+
                         item.Add("Materials", $"{materials}");
                         scrapItem.Add("Materials", $"Siemens.TCPCM.Classification.Material.Scrap");
                         item.Add("Designation", $"[DYA]{row.Cells[category].Value}");


### PR DESCRIPTION
Material DB불러오기 버튼 추가.
1.DB에서 지역,Plant,통화,품명(재질멍_GRADE),단위 등을 검색해서 가져온 값들을 넣음
2.Valid From은 날짜 선택 창을 하나 띄워서 거기서 선택한 값을 일괄적으로 입력.
3.단가는 알아서 입력하도록 비워둠.

재료-기타를 선택하고 저장 시, Substance 생성시에 Technology의 값을 사출로 설정하도록 변경.

Material 생성 시, 사출,프레스,주조에 포함되지 않는 기타 소재명들의 specification값을 전부 사출값으로 지정하도록 변경.